### PR TITLE
ROM and video fixes

### DIFF
--- a/src/fpga/core/core_top.sv
+++ b/src/fpga/core/core_top.sv
@@ -532,7 +532,8 @@ always_ff @(posedge clk_sys) begin
 	reg old_download;
 	old_download <= cart_download;
 
-	if (old_download & ~cart_download) rom_sz <= (ioctl_addr[24:0]);
+    // ROM size is the last written word's address, plus one more word
+	if (old_download & ~cart_download) rom_sz <= (ioctl_addr[24:0]+2);
 end
 
 reg  [1:0] region_req;


### PR DESCRIPTION
This PR fixes two of the biggest issues affecting reliability with the core. See the commit messages for the gory details.

The process of fixing the first issue (ROM loading) was basically just logical deduction and experimentation, but the second issue (red line) was helped substantially by SignalTap.

I noticed the SDRAM controller was being quite thorougly misused, but some games did work and trying to fix it just broke things further, so I left that alone. Basically the data loader should toggle the request signal while loading the address and data to start a transaction, then wait patiently and avoid changing any inputs until the acknowledge signal is toggled and ends up the same value as the request signal, letting the loader know it is safe to proceed further. The latency is variable due to refresh and other port activity. Brute forcing it seems to have worked well enough, but this really should be fixed.
