### PR TITLE
Update date_release to release date of 0.1.0

### DIFF
--- a/dist/Cores/ericlewis.Genesis/core.json
+++ b/dist/Cores/ericlewis.Genesis/core.json
@@ -8,7 +8,7 @@
             "author": "ericlewis",
             "url": "https://github.com/ericlewis/openfpga-genesis",
             "version": "0.1.0",
-            "date_release": "2022-09-22"
+            "date_release": "2022-10-03"
         },
         "framework": {
             "target_product": "Analogue Pocket",


### PR DESCRIPTION
While doing some work on the Cores API, I noticed that the `date_release` value wasn't updated with the release of `0.1.0`.