### PR TITLE
feat: Reset core option.

### DIFF
--- a/dist/Cores/ericlewis.Genesis/interact.json
+++ b/dist/Cores/ericlewis.Genesis/interact.json
@@ -3,6 +3,14 @@
         "magic": "APF_VER_1",
         "variables": [
             {
+                "name": "Reset Core",
+                "id": 2,
+                "type": "action",
+                "enabled": true,
+                "address": "0x00000070",
+                "value": 1
+            },
+            {
                 "name": "Region",
                 "id": 99,
                 "type": "list",


### PR DESCRIPTION
This is required for some games like X-Men (Beating the game after Mojo's stage) and X-Men 2 (to select starting character) as well as a others. The reset is simulated to be held at a "random" length of time so X-Men 2's character select will pick different characters.